### PR TITLE
'cleared' is a list not a dictionary.

### DIFF
--- a/MeteorClient.py
+++ b/MeteorClient.py
@@ -26,7 +26,7 @@ class CollectionData(object):
         for key, value in fields.items():
             self.data[collection][id][key] = value
 
-        for key, value in cleared.items():
+        for key in cleared:
             del self.data[collection][id][key]
 
     def remove_data(self, collection, id):


### PR DESCRIPTION
MeteorClient crashes when a change is sent from the meteor server that deletes a field. Looks like it is because `cleared` which is passed into `changed_data` is a list and not a dictionary. The attached patch seems to fix it.

Thanks for python-meteor - it is very useful ;)
