### PR TITLE
update connected status when reconnecting.

### DIFF
--- a/MeteorClient.py
+++ b/MeteorClient.py
@@ -68,6 +68,7 @@ class MeteorClient(EventEmitter):
                 if error:
                     raise MeteorClientException('Failed to re-authenticate during reconnect')
                     return
+                self.connected = True
                 self._resubscribe()
             self.ddp_client.call('login', self._login_data, callback=reconnect_login_callback)
         else:


### PR DESCRIPTION
this is required when python-ddp only sends either 'connected' or
'reconnected' events and not both. see [python-ddp pull req](https://github.com/hharnisc/python-ddp/pull/2)