### PR TITLE
README edited.

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ _fields_ - the fields for item
 Register the event to a callback function
 
 ```python
-def changed(self, collection, id, fields, cleared):
+def changed(collection, id, fields, cleared):
     print('* CHANGED {} {}'.format(collection, id))
     for key, value in fields.items():
         print('  - FIELD {} {}'.format(key, value))


### PR DESCRIPTION
def changed(self, collection, id, fields, cleared)  =>  def changed(collection, id, fields, cleared)

It doesn't need self, and It also cause type error.
TypeError: changed() takes exactly 5 arguments (4 given)