### PR TITLE
Add support for meteor login resume tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv
 dist
 *.egg-info
 *.pyc
+build

--- a/README.md
+++ b/README.md
@@ -181,16 +181,17 @@ _url_ - to connect to ddp server
 _auto_reconnect_ - automatic reconnect (default: True)  
 _auto_reconnect_timeout_ - reconnect every X seconds (default: 0.5)  
 _debug_ - print out lots of debug info (default: False)  
-     
+
 ### Functions
 
 ####connect()
 
 Connect to the meteor server
 
-####login(user, password, callback=None)
+####login(user, password, token=token, callback=None)
 
-Login with a username and password
+Login with a username and password. If a token is provided it will be tried first, falling back to username and password if
+the token is invalid.
 
 **Arguments**
 
@@ -199,6 +200,7 @@ _password_ - the password for the account
 
 **Keyword Arguments**
 
+_token_ - meteor resume token
 _callback_ - callback function containing error as first argument and login data  
 
 ####logout(callback=None)


### PR DESCRIPTION
If the token is not valid then it will automatically retry using
the username/email and password. this way there is no need to
check if the token is expired, although you end up making an extra
call.

Tokens are automatically saved for use when a reconnection is
required, and you can also pass an optional token into the login
method so that your app can persist it between runs.

Not sure if this is the cleanest way of doing this, but it seems to work :wink: 
