### PR TITLE
Fixed a Duplicate Values Bug

### DIFF
--- a/MeteorClient.py
+++ b/MeteorClient.py
@@ -249,7 +249,7 @@ class MeteorClient(EventEmitter):
             if selector == {}:
                 results.append(doc)
             for key, value in selector.items():
-                if key in doc and doc[key] == value:
+                if doc not in results and key in doc and doc[key] == value:
                     results.append(doc)
         return results
 


### PR DESCRIPTION
If you have multiple selectors that could potentially select the same value, the software was producing a duplicate since it just appended the value to the list twice. By checking to see if the object is already in the list, we no longer get duplicates. Consider, for example, a collection with the item:
`{userId: 'asdfghjkl', enabled: True, ...`
Now, if we performed the query:
`client.find('whatever', selector={'userId': 'asdfghjkl', 'enabled': True})`
previously, we would have gotten that same item back twice.
